### PR TITLE
Add Terraform-based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ go run ./cmd/server
 ```
 
 The server listens on `localhost:8080` and expects a PostgreSQL instance configured via `DATABASE_URL` (defaults to `postgres://postgres:postgres@localhost:5432/squirrel?sslmode=disable`).
+
+## Deploying with Terraform
+
+Terraform configuration in the `infra/` directory can be used to run the API server and a PostgreSQL database using Docker containers.
+
+```bash
+cd infra
+terraform init
+terraform apply
+```
+
+The server will listen on port `8080` and the database will listen on port `5432` of your Docker host.

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM golang:1.20 AS build
+WORKDIR /app
+COPY go.mod .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server ./cmd/server
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian11
+COPY --from=build /app/server /server
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.20"
+    }
+  }
+}
+
+provider "docker" {}
+
+resource "docker_network" "squirrel" {
+  name = "squirrel_net"
+}
+
+resource "docker_image" "postgres" {
+  name = "postgres:15"
+}
+
+resource "docker_container" "db" {
+  name  = "squirrel_db"
+  image = docker_image.postgres.latest
+
+  env = [
+    "POSTGRES_USER=postgres",
+    "POSTGRES_PASSWORD=postgres",
+    "POSTGRES_DB=squirrel"
+  ]
+
+  networks_advanced {
+    name = docker_network.squirrel.name
+    aliases = ["db"]
+  }
+
+  ports {
+    internal = 5432
+    external = 5432
+  }
+}
+
+resource "docker_image" "server" {
+  name = "squirrel-server"
+  build {
+    context    = "${path.module}/.."
+    dockerfile = "${path.module}/Dockerfile"
+  }
+}
+
+resource "docker_container" "server" {
+  name  = "squirrel_server"
+  image = docker_image.server.latest
+
+  depends_on = [docker_container.db]
+
+  env = [
+    "DATABASE_URL=postgres://postgres:postgres@db:5432/squirrel?sslmode=disable"
+  ]
+
+  networks_advanced {
+    name    = docker_network.squirrel.name
+    aliases = ["server"]
+  }
+
+  ports {
+    internal = 8080
+    external = 8080
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform config under `infra/` to launch a Postgres DB and API server in Docker containers
- provide Dockerfile for server image
- document Terraform usage in README

## Testing
- `go test ./...`
- ❌ `terraform version` *(fails: command not found)*